### PR TITLE
CommandWrapper now owns its commands

### DIFF
--- a/src/main/java/org/mose/command/BukkitCommandWrapper.java
+++ b/src/main/java/org/mose/command/BukkitCommandWrapper.java
@@ -13,11 +13,24 @@ import java.util.stream.Collectors;
 
 public class BukkitCommandWrapper implements TabExecutor {
 
-    public static final Set<ArgumentCommand> COMMANDS = new HashSet<>();
+    public final Set<ArgumentCommand> commands = new HashSet<>();
+
+    @Deprecated
+    public BukkitCommandWrapper() {
+        throw new RuntimeException("A ArgumentCommand needs to be specified");
+    }
+
+    public BukkitCommandWrapper(ArgumentCommand... commands) {
+        this(Arrays.asList(commands));
+    }
+
+    public BukkitCommandWrapper(Collection<ArgumentCommand> commands) {
+        this.commands.addAll(commands);
+    }
 
     @Override
     public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, String[] strings) {
-        CommandContext commandContext = new CommandContext(commandSender, COMMANDS, strings);
+        CommandContext commandContext = new CommandContext(commandSender, this.commands, strings);
         Optional<ArgumentCommand> opCommand = commandContext.getCompleteCommand();
         if (!opCommand.isPresent()) {
             Set<ErrorContext> errors = commandContext.getErrors();
@@ -35,15 +48,15 @@ public class BukkitCommandWrapper implements TabExecutor {
             return true;
         }
         if (!opCommand.get().hasPermission(commandSender)) {
-                commandSender.sendMessage(ChatColor.RED + " You do not have permission for that command. You require " + opCommand.get().getPermissionNode());
-                return true;
+            commandSender.sendMessage(ChatColor.RED + " You do not have permission for that command. You require " + opCommand.get().getPermissionNode());
+            return true;
         }
         return opCommand.get().run(commandContext, strings);
     }
 
     @Override
     public List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, String[] strings) {
-        CommandContext commandContext = new CommandContext(commandSender, COMMANDS, strings);
+        CommandContext commandContext = new CommandContext(commandSender, this.commands, strings);
         Set<ArgumentCommand> commands = commandContext.getPotentialCommands();
         TreeSet<String> tab = new TreeSet<>();
         commands.forEach(c -> {


### PR DESCRIPTION
The following is now how to register commands

```java
    ArgumentCommand command1;
    ArgumentCommand command2;
    BukkitCommandWrapper wrapper = new BukkitCommandWrapper(command1, command2);
```

or 

```java
    Collection<ArgumentCommand> commands;
    BukkitCommandWrapper wrapper = new BukkitCommandWrapper(commands);
```